### PR TITLE
Work around the missing source name in partial SDRF file

### DIFF
--- a/ParsingModule.py
+++ b/ParsingModule.py
@@ -376,7 +376,9 @@ def convert_df(df):
     factor_value_cols = sorted([i for i in cols if i.startswith("factor")])
     #get all columns that don't start with "characteristic" or "comment"
     other_cols = [i for i in cols if i not in characteristic_cols and i not in comment_cols and i not in factor_value_cols and i not in ["source name"]]
-    #reorder the columns
+    #reorder the columns, add "source name" if it is missing
+    if "source name" not in df:
+        df["source name"] = ""
     new_cols = ["source name"] + characteristic_cols + other_cols + comment_cols + factor_value_cols
     df = df[new_cols]
     #if a column name contains _ followed by a number, remove the underscore and the number


### PR DESCRIPTION
Fixes #5.

When uploading a partial SDRF without the "source name" column, it is created and filled with empty strings, avoiding a `KeyError`.

**Important**: there is currently no way (as far as I can see) to **edit** the source names later. The site suggests to "reannotate" source names, but it doesn't work. Should I make a separate issue?