### PR TITLE
Fix for the case when a single raw file name is entered

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -152,6 +152,8 @@ if selected_species != "":
             uploaded_names = uploaded_names.split("\t")
         elif " " in uploaded_names:
             uploaded_names = uploaded_names.split(" ")
+        else:
+            uploaded_names = [uploaded_names]
         #remove trailing and leading spaces
         uploaded_names = [name.strip() for name in uploaded_names]
         filenames.append(uploaded_names)


### PR DESCRIPTION
Properly handle the case when the user enters a single raw file name. Before, this name would be split into single characters:

![image](https://github.com/user-attachments/assets/c2ec3bb0-0dcc-4fb1-a35a-121b2442fade)
